### PR TITLE
Make the type of 'content' abstract.

### DIFF
--- a/record.ml
+++ b/record.ml
@@ -60,8 +60,9 @@ let field (type s) (type a) (layout: s layout) label (ty : a Type.t):
 type 'a t =
   {
     layout: 'a layout;
-    content: 'a;
+    content: 'a content;
   }
+and 'a content
 
 exception AllocatingUnsealedStruct of string
 

--- a/record.mli
+++ b/record.mli
@@ -36,8 +36,9 @@ val layout_id: 's layout -> 's Polid.t
 type 's t =
   {
     layout: 's layout;
-    content: 's;
+    content: 's content;
   }
+and 's content
 
 (** Allocate a record of a given layout, with all fields initially unset. *)
 val make: 's layout -> 's t


### PR DESCRIPTION
This PR improves the type safety of the interface by making the type of the `contents` field abstract.

In the current release, the type of the `content` field is simply the type parameter of the record, chosen by the user, which can lead to unpleasant surprises.  For example, a value of type `string t` has a `content` field of type `string`, which causes problems when the top level attempts to print it:

``` ocaml
# let r = Record.declare "r";;
val r : '_a Record.layout = <abstr>
# Record.seal r;;
- : unit = ()
# (Record.make r : string Record.t) ;;
Segmentation fault
```

With this patch the type of `content` is abstract and cannot be accessed:

``` ocaml
# let r = Record.declare "r";;
val r : '_a Record.layout = <abstr>
# Record.seal r;;
- : unit = ()
# (Record.make r : string Record.t) ;;
- : string Record.t = {Record.layout = <abstr>; content = <abstr>}
```
