### PR TITLE
Add a Safe sub-module for type-safe creation of layouts.

### DIFF
--- a/record.ml
+++ b/record.ml
@@ -188,3 +188,31 @@ let declare4 ~name ~f1_name ~f1_type ~f2_name ~f2_type
   let f4 = field layout f4_name f4_type in
   seal layout;
   (layout, f1, f2, f3, f4)
+
+module Safe =
+struct
+  module type LAYOUT =
+  sig
+    type s
+    val layout : s layout
+    val field : string -> 'a Type.t -> ('a, s) field
+    val seal : unit -> unit
+    val layout_name : string
+    val layout_id : s Polid.t
+    val make : unit -> s t
+  end
+
+  module Declare(X: sig val name : string end) : LAYOUT =
+  struct
+    type s
+    let layout = declare X.name
+    let field n t = field layout n t
+    let seal () = seal layout
+    let layout_name = layout.name
+    let layout_id = layout.uid
+    let make () = make layout
+  end
+
+  let declare : string -> (module LAYOUT) =
+    fun name -> (module (Declare (struct let name = name end)))
+end

--- a/record.mli
+++ b/record.mli
@@ -57,6 +57,36 @@ val set: 's t -> ('a,'s) field -> 'a -> unit
 (** Raised by [get] if the field was not set. *)
 exception UndefinedField of string
 
+(** {3} Safe interface *)
+module Safe :
+sig
+  module type LAYOUT =
+  sig
+    type s
+
+    (** A value representing the layout. *)
+    val layout : s layout
+
+    (** Add a field to the layout. This modifies the layout and returns the field. *)
+    val field : string -> 'a Type.t -> ('a, s) field
+
+    (** Make the layout unmodifiable. It is necessary before constructing values. *)
+    val seal : unit -> unit
+
+    (** The name that was given to the layout. *)
+    val layout_name : string
+
+    (** The unique identifier given to a layout. *)
+    val layout_id : s Polid.t
+
+    (** Allocate a record of the layout, with all fields initially unset. *)
+    val make : unit -> s t
+  end
+
+  (** Create a new layout with the given name. *)
+  val declare : string -> (module LAYOUT)
+end
+
 (** {2} Miscellaneous *)
 
 (** Convert a record to JSON. *)

--- a/tests.ml
+++ b/tests.ml
@@ -15,13 +15,42 @@ let rlt : l Record.layout = Record.declare "rl"
 let value_l = Record.field rlt "value_list" (Type.list Type.int)
 let () = Record.seal rlt
 
+module Safe_layouts =
+struct
+  module Rt = (val Record.Safe.declare "r")
+  let x = Rt.field "x" Type.int
+  let () = Rt.seal ()
+
+  module Rpt = (val Record.Safe.declare "rp")
+  let value_p = Rpt.field "value_pair" (Type.product_2 "fst" Type.int "snd" Type.int)
+  let () = Rpt.seal ()
+
+  module Rlt = (val Record.Safe.declare "rl")
+  let value_l = Rlt.field "value_list" (Type.list Type.int)
+  let () = Rlt.seal ()
+end
+
 let set_get ctxt =
   let r = Record.make rt in
   Record.set r x 2;
   assert_equal 2 (Record.get r x)
 
+let safe_set_get ctxt =
+  let open Safe_layouts in
+  let r = Record.make Rt.layout in
+  Record.set r x 2;
+  assert_equal 2 (Record.get r x)
+
 let get_undef ctxt =
   let r = Record.make rt in
+  let e = Record.UndefinedField "x" in
+  assert_raises e (fun () ->
+    Record.get r x
+  )
+
+let safe_get_undef ctxt =
+  let open Safe_layouts in
+  let r = Record.make Rt.layout in
   let e = Record.UndefinedField "x" in
   assert_raises e (fun () ->
     Record.get r x
@@ -33,10 +62,24 @@ let extend_after_seal ctxt =
     Record.field rt "y" Type.int
   )
 
+let safe_extend_after_seal ctxt =
+  let open Safe_layouts in
+  let e = Record.ModifyingSealedStruct "r" in
+  assert_raises e (fun () ->
+    Record.field Rt.layout "y" Type.int
+  )
+
 let seal_twice ctxt =
   let e = Record.ModifyingSealedStruct "r" in
   assert_raises e (fun () ->
     Record.seal rt
+  )
+
+let safe_seal_twice ctxt =
+  let open Safe_layouts in
+  let e = Record.ModifyingSealedStruct "r" in
+  assert_raises e (fun () ->
+    Record.seal Rt.layout
   )
 
 let make_unsealed ctxt (type r2) =
@@ -47,8 +90,19 @@ let make_unsealed ctxt (type r2) =
     Record.make rt2
   )
 
+let safe_make_unsealed ctxt (type r2) =
+  let module Rt2 = (val Record.Safe.declare "r2") in
+  let _x2 = Rt2.field "x2" Type.int in
+  let e = Record.AllocatingUnsealedStruct "r2" in
+  assert_raises e (fun () ->
+    Record.make Rt2.layout
+  )
+
 let layout_name ctxt =
   assert_equal "r" (Record.layout_name rt)
+
+let safe_layout_name ctxt =
+  assert_equal "r" Safe_layouts.Rt.layout_name
 
 let layout_id ctxt =
   let id1 = Record.layout_id rt in
@@ -58,11 +112,23 @@ let layout_id ctxt =
   assert_equal ~msg:"layout_id is pure (int)" (Polid.to_int id1) (Polid.to_int id2);
   assert_bool "fresh returns a different id" (Polid.equal id1 id3 = Polid.Different)
 
+let safe_layout_id ctxt =
+  let open Safe_layouts in
+  let id1 = Rt.layout_id in
+  let id2 = Polid.fresh () in
+  assert_bool "fresh returns a different id" (Polid.equal id1 id2 = Polid.Different)
+
 let field_name ctxt =
   assert_equal "x" (Record.field_name x)
 
+let safe_field_name ctxt =
+  assert_equal "x" (Record.field_name Safe_layouts.x)
+
 let field_type ctxt =
   assert_equal "int" (Record.field_type x).Type.name
+
+let safe_field_type ctxt =
+  assert_equal "int" (Record.field_type Safe_layouts.x).Type.name
 
 let record_layout ctxt =
   let r = Record.make rt in
@@ -73,10 +139,25 @@ let record_layout ctxt =
       (Record.layout_id rt)
     )
 
+let safe_record_layout ctxt =
+  let open Safe_layouts in
+  let r = Rt.make () in
+  let l = Record.get_layout r in
+  assert_bool "layout is the same"
+    (Polid.is_equal
+      (Record.layout_id l)
+      Rt.layout_id
+    )
+
 let of_json ctxt =
   let j = `Assoc [("x", `Int 2)] in
   let r = Record.of_json rt j in
   assert_equal 2 (Record.get r x)
+
+let safe_of_json ctxt =
+  let j = `Assoc [("x", `Int 2)] in
+  let r = Record.of_json Safe_layouts.Rt.layout j in
+  assert_equal 2 (Record.get r Safe_layouts.x)
 
 let to_json ctxt =
   let r = Record.make rt in
@@ -85,8 +166,23 @@ let to_json ctxt =
   let printer = Yojson.Basic.pretty_to_string in
   assert_equal ~printer expected (Record.to_json r)
 
+let safe_to_json ctxt =
+  let open Safe_layouts in
+  let r = Rt.make () in
+  Record.set r x 2;
+  let expected = `Assoc [("x", `Int 2)] in
+  let printer = Yojson.Basic.pretty_to_string in
+  assert_equal ~printer expected (Record.to_json r)
+
 let to_json_null ctxt =
   let r = Record.make rt in
+  let expected = `Assoc [("x", `Null)] in
+  let printer = Yojson.Basic.pretty_to_string in
+  assert_equal ~printer expected (Record.to_json r)
+
+let safe_to_json_null ctxt =
+  let open Safe_layouts in
+  let r = Rt.make () in
   let expected = `Assoc [("x", `Null)] in
   let printer = Yojson.Basic.pretty_to_string in
   assert_equal ~printer expected (Record.to_json r)
@@ -109,6 +205,25 @@ let json_product ctxt  =
   let recovered = Record.of_json rpt json in
   assert_equal (3, 14) (Record.get recovered value_p)
 
+let safe_json_product ctxt  =
+  let open Safe_layouts in
+  let r = Rpt.make () in
+  Record.set r value_p (3, 14);
+  let json =
+    `Assoc
+      [ ("value_pair"
+        , `Assoc
+             [ ("fst", `Int 3)
+             ; ("snd", `Int 14)
+             ]
+        )
+      ]
+  in
+  let printer = Yojson.Basic.pretty_to_string in
+  assert_equal ~printer json (Record.to_json r);
+  let recovered = Record.of_json Rpt.layout json in
+  assert_equal (3, 14) (Record.get recovered value_p)
+
 let json_list ctxt =
   let r = Record.make rlt in
   Record.set r value_l [3; 14; 15];
@@ -126,6 +241,26 @@ let json_list ctxt =
   let printer = Yojson.Basic.pretty_to_string in
   assert_equal ~printer json (Record.to_json r);
   let recovered = Record.of_json rlt json in
+  assert_equal [3; 14; 15] (Record.get recovered value_l)
+
+let safe_json_list ctxt =
+  let open Safe_layouts in
+  let r = Rlt.make () in
+  Record.set r value_l [3; 14; 15];
+  let json =
+    `Assoc
+      [ ("value_list"
+        , `List
+             [ `Int 3
+             ; `Int 14
+             ; `Int 15
+             ]
+        )
+      ]
+  in
+  let printer = Yojson.Basic.pretty_to_string in
+  assert_equal ~printer json (Record.to_json r);
+  let recovered = Record.of_json Rlt.layout json in
   assert_equal [3; 14; 15] (Record.get recovered value_l)
 
 let declare0 ctxt =
@@ -194,6 +329,27 @@ let layout_type ctxt =
   in
   assert_equal ~ctxt ~printer expected (Record.to_json rp)
 
+let safe_layout_type ctxt =
+  let open Safe_layouts in
+  let rt_typ = Record.layout_type Rt.layout in
+  let module La = (val Record.Safe.declare "pair") in
+  let fa1 = La.field "f1" rt_typ in
+  let fa2 = La.field "f2" rt_typ in
+  let () = La.seal () in
+  let r = Rt.make () in
+  Record.set r x 3;
+  let rp = La.make () in
+  Record.set rp fa1 r;
+  Record.set rp fa2 r;
+  let printer = Yojson.Basic.pretty_to_string in
+  let expected =
+    `Assoc
+      [ ("f1", `Assoc [("x", `Int 3)])
+      ; ("f2", `Assoc [("x", `Int 3)])
+      ]
+  in
+  assert_equal ~ctxt ~printer expected (Record.to_json rp)
+
 let view ctxt =
   let open Type in
   let int_array =
@@ -232,6 +388,22 @@ let suite =
     ; "declare4" >:: declare4
     ; "layout_type" >:: layout_type
     ; "view" >:: view
+    ; "Safe set & get" >:: safe_set_get
+    ; "Safe get undefined field" >:: safe_get_undef
+    ; "Safe extend a sealed layout" >:: safe_extend_after_seal
+    ; "Safe seal a sealed layout" >:: safe_seal_twice
+    ; "Safe instanciate an unsealed layout" >:: safe_make_unsealed
+    ; "Safe layout name" >:: safe_layout_name
+    ; "Safe layout id" >:: safe_layout_id
+    ; "Safe field name" >:: safe_field_name
+    ; "Safe field type" >:: safe_field_type
+    ; "Safe record layout" >:: safe_record_layout
+    ; "Safe JSON reader" >:: safe_of_json
+    ; "Safe JSON writer" >:: safe_to_json
+    ; "Safe JSON writer (null field)" >:: safe_to_json_null
+    ; "Safe JSON (product)" >:: safe_json_product
+    ; "Safe JSON (list)" >:: safe_json_list
+    ; "Safe layout_type" >:: safe_layout_type
     ]
 
 let _ = run_test_tt_main suite


### PR DESCRIPTION
This PR adds a `Safe` submodule that guarantees that distinct record layouts are always given distinct types, increasing type safety.
### The problem

Here are two record layouts, `foo` and `bar`, each with a field named `"x"`.  The field accessors are bound to variables `foo_x` and `bar_x`:

``` ocaml
# let foo = Record.declare "foo"
  and bar = Record.declare "bar";;
val foo : '_a Record.layout = <abstr>
val bar : '_a Record.layout = <abstr>
# let foo_x = Record.field foo "x" Type.int
  and bar_x = Record.field bar "x" Type.string;;
val foo_x : (int, '_a) Record.field = <abstr>
val bar_x : (string, '_a) Record.field = <abstr>
# let () = Record.seal foo
  and () = Record.seal bar ;;
```

We can create an instance of `foo`:

``` ocaml
# let rfoo = Record.make foo;;
val rfoo : '_a Record.t = {Record.layout = <abstr>; content = <abstr>}
```

then store a field using `foo_x`

``` ocaml
# let () = Record.set rfoo foo_x 3
```

and attempt to retrieve the field using `foo_y`:

``` ocaml
# let _ = Record.get rfoo foo_y;;
Segmentation fault
```

The problem, of course, is that the layouts `foo` and `bar` have compatible types, since we forgot to instantiate their type parameters.
### The solution

This PR adds a `Safe` submodule based on first-class modules that gives record layouts distinct types without requiring the user to explicitly instantiate type parameters.  The idea is to make the type parameter an abstract field in a module type:

``` ocaml
  module type LAYOUT =
  sig
    type s
    val layout : s layout
    (* ... *)
  end
```

and expose a second version of `declare` that creates instances of `LAYOUT`:

``` ocaml
  val declare : string -> (module LAYOUT)
```

Here's a second version of the example above, using the new safe interface.  This time, attempting to use the wrong field results in a type error rather than a segmentation fault:

``` ocaml
# module Foo = (val Record.Safe.declare "foo");;
module Foo : Record.Safe.LAYOUT
# module Bar = (val Record.Safe.declare "bar");;
module Bar : Record.Safe.LAYOUT
# let foo_x = Foo.field "x" Type.int
  and bar_x = Bar.field "y" Type.string;;
val foo_x : (int, Foo.s) Record.field = <abstr>
val bar_x : (string, Bar.s) Record.field = <abstr>
# let () = Foo.seal () and () = Bar.seal ();;
# let rfoo = Foo.make ();;
val rfoo : Foo.s Record.t = {Record.layout = <abstr>; content = <abstr>}
# let () = Record.set rfoo foo_x 3;;
# let _ = Record.get rfoo bar_x;;
Characters 24-29:
  let _ = Record.get rfoo bar_x;;
                          ^^^^^
Error: This expression has type (string, Bar.s) Record.field
       but an expression was expected of type (string, Foo.s) Record.field
       Type Bar.s is not compatible with type Foo.s
```
### Notes

As the example shows, the `LAYOUT` module also includes layout-specific versions of `field`, `seal`, `make`, etc.  I haven't included safe versions of the convenience functions `declare0`, `declare1`, etc., but it would be straightforward to do so.
