### PR TITLE
Deprecate Record.format

### DIFF
--- a/src/record.mli
+++ b/src/record.mli
@@ -250,3 +250,4 @@ val equal: 'a layout -> 'b layout -> ('a, 'b) Polid.equal
 
 (** Print the JSON representation of a record to a formatter. *)
 val format: Format.formatter -> 'a t -> unit
+[@@deprecated "Please use Yojson.Safe.to_string instead"]

--- a/test/example.ml
+++ b/test/example.ml
@@ -12,4 +12,4 @@ let _ =
   Record.set p x 3;
   Record.set p y 4;
   Record.set p z 5;
-  Record.format Format.std_formatter p
+  Yojson.Safe.to_channel stdout @@ Record.to_yojson p


### PR DESCRIPTION
This adds an explicit dependency on yojson and can be done from outside the
library.
