### PR TITLE
Remove `Record.format`

### DIFF
--- a/src/record.ml
+++ b/src/record.ml
@@ -413,9 +413,6 @@ module Util = struct
     (layout, f1, f2, f3, f4)
 end
 
-let format (type s) fmt (s: s t) : unit =
-  Format.fprintf fmt "%s" (Yojson.Safe.to_string (to_yojson s))
-
 module Safe =
 struct
   module type LAYOUT =

--- a/src/record.mli
+++ b/src/record.mli
@@ -255,7 +255,3 @@ end
 
 (** Equality predicate. *)
 val equal: 'a layout -> 'b layout -> ('a, 'b) Polid.equal
-
-(** Print the JSON representation of a record to a formatter. *)
-val format: Format.formatter -> 'a t -> unit
-[@@deprecated "Please use Yojson.Safe.to_string instead"]


### PR DESCRIPTION
It was deprecated in 0.7.0.