### PR TITLE
Fix deprecation issue and Yojson 2.x compatibility

### DIFF
--- a/records.opam
+++ b/records.opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.02.0"}
   "ounit" {with-test & >= "2.0.0"}
   "result"
-  "yojson"
+  "yojson" {>= "1.6.0"}
 ]
 tags: ["org:cryptosense"]
 synopsis: "Dynamic records"

--- a/src/record.ml
+++ b/src/record.ml
@@ -34,8 +34,8 @@ end
 module Type = struct
   type 'a t =
     { name: string;
-      to_yojson: ('a -> Yojson.Safe.json);
-      of_yojson: (Yojson.Safe.json -> ('a, string) result);
+      to_yojson: ('a -> Yojson.Safe.t);
+      of_yojson: (Yojson.Safe.t -> ('a, string) result);
     }
 
   let name t = t.name
@@ -303,7 +303,7 @@ let set record field value =
    error, map them to `Null, or skip the field. If some fields might
    not be set, we should use the 2nd or the 3rd. Maybe this kind of
    behavior could be set at field creation time? *)
-let to_yojson (type s) (s : s t) : Yojson.Safe.json =
+let to_yojson (type s) (s : s t) : Yojson.Safe.t =
   let fields =
     List.map
       (fun (BoxedField f) ->
@@ -320,7 +320,7 @@ let to_yojson (type s) (s : s t) : Yojson.Safe.json =
 
 (* todo: the error handling here is plain wrong. Should do something
    special in the `Null case.  *)
-let of_yojson (type s) (s: s layout) (json: Yojson.Safe.json) : (s t, string) result =
+let of_yojson (type s) (s: s layout) (json: Yojson.Safe.t) : (s t, string) result =
   let open Json_safe in
   let r = Unsafe.make s in
   let field_value (BoxedField f) =

--- a/src/record.mli
+++ b/src/record.mli
@@ -34,14 +34,14 @@ module Type : sig
   type 'a t
 
   val name : 'a t -> string
-  val of_yojson : 'a t -> (Yojson.Safe.json -> ('a, string) Result.result)
-  val to_yojson : 'a t -> ('a -> Yojson.Safe.json)
+  val of_yojson : 'a t -> (Yojson.Safe.t -> ('a, string) Result.result)
+  val to_yojson : 'a t -> ('a -> Yojson.Safe.t)
 
   (** Declare a new type. *)
   val make:
     name: string ->
-    to_yojson: ('a -> Yojson.Safe.json) ->
-    of_yojson: (Yojson.Safe.json -> ('a, string) Result.result) ->
+    to_yojson: ('a -> Yojson.Safe.t) ->
+    of_yojson: (Yojson.Safe.t -> ('a, string) Result.result) ->
     unit -> 'a t
 
   (** Declare a new type that marshal/unmarshal to strings. *)
@@ -195,10 +195,10 @@ end
 (** {2 Miscellaneous} *)
 
 (** Convert a record to JSON. *)
-val to_yojson: 'a t -> Yojson.Safe.json
+val to_yojson: 'a t -> Yojson.Safe.t
 
 (** Convert a JSON value into a given schema. *)
-val of_yojson: 'a layout -> Yojson.Safe.json -> ('a t, string) Result.result
+val of_yojson: 'a layout -> Yojson.Safe.t -> ('a t, string) Result.result
 
 module Util : sig
   (** Get the [Type.t] representation of a layout. *)


### PR DESCRIPTION
Bumps the minimum Yojson version to 1.6.0 for the `t` type and thus makes it compatible with the upcoming Yojson 2.0.